### PR TITLE
Fix, improve Unraid templates

### DIFF
--- a/ImageMaid.xml
+++ b/ImageMaid.xml
@@ -4,7 +4,6 @@
   <Repository>kometateam/imagemaid</Repository>
   <Registry>https://hub.docker.com/r/kometateam/imagemaid</Registry>
   <Network>bridge</Network>
-  <MyIP/>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
   <Support>https://github.com/Kometa-Team/ImageMaid/issues/new/choose</Support>
@@ -20,36 +19,30 @@
     <Project>https://kometa.wiki/en/develop/</Project>
     <ReadMe>https://kometa.wiki/en/develop/kometa/scripts/imagemaid/</ReadMe>
   </Branch>
-
   <Overview>ImageMaid is a script developed by the Kometa team. This tool is designed to help manage and clean up Plex directories by removing unused overlays, custom artwork, and clearing the PhotoTranscoder Directory. It also automates Plex maintenance tasks like emptying trash, cleaning bundles, and optimizing the database.</Overview>
   <Category>Tools:Utilities Status:Stable</Category>
-  <WebUI/>
-  <TemplateURL>https://github.com/Kometa-Team/Unraid-Templates/blob/master/ImageMaid.xml<TemplateURL>
+  <TemplateURL>https://github.com/Kometa-Team/Unraid-Templates/blob/master/ImageMaid.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/Kometa-Team/ImageMaid/refs/heads/develop/.github/logo.png</Icon>
-  <ExtraParams/>
-  <PostArgs/>
-  <CPUset/>
-  <DateInstalled>1727383014</DateInstalled>
   <DonateText>Support the Kometa Developer!</DonateText>
   <DonateLink>https://github.com/sponsors/meisnate12</DonateLink>
   <Requires/>
   <Config Name="Config Directory" Target="/config" Default="" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/Overlay-Reset/</Config>
   <Config Name="Plex Config Directory" Target="/plex" Default="" Mode="rw" Description="Plex Config Directory containing the servers Metadata including Cache, Metadata, and Plug-in Support folders." Type="Path" Display="always" Required="false" Mask="false"/>
   <Config Name="Plex Config Directory (--plex)" Target="PLEX_PATH" Default="" Mode="" Description="Can set the Plex Config Directory if its not mapped to /plex." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Mode (--mode)" Target="MODE" Default="report" Mode="" Description="How ImageMaid runs depends on the Mode Option that's currently set for that run. \nOptions: report, move, restore, clear, remove, nothing." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Mode (--mode)" Target="MODE" Default="report|move|restore|clear|remove|nothing" Mode="" Description="How ImageMaid runs depends on the Mode Option that's currently set for that run." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Plex URL (--url)" Target="PLEX_URL" Default="" Mode="" Description="Plex URL for downloading the Database from the Plex API." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Plex Token (--token)" Target="PLEX_TOKEN" Default="" Mode="" Description="Plex Token for downloading the Database from the Plex API." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Use Local Database (--local)" Target="LOCAL_DB" Default="False" Mode="" Description="Use the local /plex directory to grab the database. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Ignore Runnng (--ignore)" Target="IGNORE_RUNNING" Default="False" Mode="" Description="Allows a run while the database is currently in use. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Use Existing (--existing)" Target="USE_EXISTING" Default="False" Mode="" Description="Use previously downloaded or copied database can be used if it's less than 2 hours old. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Photo Transcoder (--photo-transcoder)" Target="PHOTO_TRANSCODER" Default="False" Mode="" Description="Also clean then PhotoTranscoder Directory. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Empty Trash (--empty-trash)" Target="EMPTY_TRASH" Default="False" Mode="" Description="Also run the Empty Trash Plex Operation. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Clean Bundles (--clean-bundles)" Target="CLEAN_BUNDLES" Default="False" Mode="" Description="Also run the Clean Bundles Plex Operation. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Optimize DB (--optimize-db)" Target="OPTIMIZE_DB" Default="False" Mode="" Description="Also run the Optimize DB Plex Operation. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Discord URL (--discord)" Target="DISCORD" Default="False" Mode="" Description="Discord Webhook URL to send notifications to." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Use Local Database (--local)" Target="LOCAL_DB" Default="False|True" Mode="" Description="Use the local /plex directory to grab the database." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Ignore Runnng (--ignore)" Target="IGNORE_RUNNING" Default="False|True" Mode="" Description="Allows a run while the database is currently in use." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Use Existing (--existing)" Target="USE_EXISTING" Default="False|True" Mode="" Description="Use previously downloaded or copied database can be used if it's less than 2 hours old." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Photo Transcoder (--photo-transcoder)" Target="PHOTO_TRANSCODER" Default="False|True" Mode="" Description="Also clean then PhotoTranscoder Directory." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Empty Trash (--empty-trash)" Target="EMPTY_TRASH" Default="False|True" Mode="" Description="Also run the Empty Trash Plex Operation." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Clean Bundles (--clean-bundles)" Target="CLEAN_BUNDLES" Default="False|True" Mode="" Description="Also run the Clean Bundles Plex Operation." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Optimize DB (--optimize-db)" Target="OPTIMIZE_DB" Default="False|True" Mode="" Description="Also run the Optimize DB Plex Operation." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Discord URL (--discord)" Target="DISCORD" Default="" Mode="" Description="Discord Webhook URL to send notifications to." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Timeout (--timeout)" Target="TIMEOUT" Default="600" Mode="" Description="Connection Timeout in seconds that's greater than 0." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Sleep (--sleep)" Target="SLEEP" Default="60" Mode="" Description="Sleep Timer between Empty Trash, Clean Bundles, and Optimize DB in seconds that's greater than 0." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Trace (--trace)" Target="TRACE" Default="False" Mode="" Description="Run with extra trace logs. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Log Requests (--log-requests)" Target="LOG_REQUESTS" Default="False" Mode="" Description="Run with every request and file action logged. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Trace (--trace)" Target="TRACE" Default="False|True" Mode="" Description="Run with extra trace logs." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Log Requests (--log-requests)" Target="LOG_REQUESTS" Default="False|True" Mode="" Description="Run with every request and file action logged." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Continuous Schedule (--schedule)" Target="SCHEDULE" Default="" Mode="" Description="See https://kometa.wiki/en/latest/kometa/scripts/imagemaid/#continuous-schedule for how to schedule." Type="Variable" Display="advanced" Required="false" Mask="false"/>
 </Container>

--- a/Kometa.xml
+++ b/Kometa.xml
@@ -4,7 +4,6 @@
   <Repository>kometateam/kometa</Repository>
   <Registry>https://hub.docker.com/r/kometateam/kometa</Registry>
   <Network>bridge</Network>
-  <MyIP/>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
   <Support>https://github.com/Kometa-Team/Kometa/issues/new/choose</Support>
@@ -30,42 +29,36 @@
 &#xD;
 Unraid Setup Guide: https://kometa.wiki/en/latest/kometa/install/unraid/</Overview>
   <Category>Tools:Utilities Status:Stable</Category>
-  <WebUI/>
   <TemplateURL>https://github.com/Kometa-Team/Unraid-Templates/blob/master/Kometa.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/Kometa-Team/Kometa/nightly/docs/_static/logomark-color.png</Icon>
-  <ExtraParams/>
-  <PostArgs/>
-  <CPUset/>
-  <DateInstalled>1672339714</DateInstalled>
   <DonateText>Support the Kometa Developer!</DonateText>
   <DonateLink>https://github.com/sponsors/meisnate12</DonateLink>
-  <Requires/>
   <Config Name="Config Directory" Target="/config" Default="" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/Kometa/</Config>
-  <Config Name="Config Location (--config)" Target="KOMETA_CONFIG" Default="" Mode="" Description="Specify the location of the configuration YAML file." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Internal Config Location (--config)" Target="KOMETA_CONFIG" Default="" Mode="" Description="Specify the internal location of the configuration YAML file." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Time to Run (--time)" Target="KOMETA_TIME" Default="" Mode="" Description="Specify the times of day that Kometa will run with comma-separated list of times in HH:MM format." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Run Immediately (--run)" Target="KOMETA_RUN" Default="" Mode="" Description="Set as 'true' to perform a run immediately, bypassing the time to run flag." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Run Tests (--run-tests)" Target="KOMETA_TEST" Default="" Mode="" Description="Set as 'true' to perform a debug test run immediately, bypassing the time to run flag. This will only run collections with test: true in the definition." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Debug (--debug)" Target="KOMETA_DEBUG" Default="" Mode="" Description="Set as 'true' to run with Debug Logs Reporting to the Command Window." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Trace (--trace)" Target="KOMETA_TRACE" Default="" Mode="" Description="Set as 'true' to run with extra Trace Debug Logs." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Log Requests (--log-requests)" Target="KOMETA_LOG_REQUESTS" Default="" Mode="" Description="Set as 'true' to run with every network request printed to the Logs. This can potentially have personal information in it." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Run Tests (--run-tests)" Target="KOMETA_TEST" Default="false|true" Mode="" Description="Set as 'true' to perform a debug test run immediately, bypassing the time to run flag. This will only run collections with test: true in the definition." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Debug (--debug)" Target="KOMETA_DEBUG" Default="false|true" Mode="" Description="Set as 'true' to run with Debug Logs Reporting to the Command Window." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Trace (--trace)" Target="KOMETA_TRACE" Default="false|true" Mode="" Description="Set as 'true' to run with extra Trace Debug Logs." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Log Requests (--log-requests)" Target="KOMETA_LOG_REQUESTS" Default="false|true" Mode="" Description="Set as 'true' to run with every network request printed to the Logs. This can potentially have personal information in it." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Timeout (--timeout)" Target="KOMETA_TIMEOUT" Default="" Mode="" Description="Change the main Kometa timeout. This timeout is overwritten by those in your config file for those services." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Collections Only (--collections-only)" Target="KOMETA_COLLECTIONS_ONLY" Default="" Mode="" Description="Set as 'true' to only run collection files, skip metadata, library operations, overlays, and playlists." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Metadata Only (--metadata-only)" Target="KOMETA_METADATA_ONLY" Default="" Mode="" Description="Set as 'true' to only run metadata files, skip library operations, overlays, playlists, and collections." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Playlists Only (--playlists-only)" Target="KOMETA_PLAYLISTS_ONLY" Default="" Mode="" Description="Set as 'true' to only run playlist files, skip metadata, library operations, overlays, and collections." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Operations Only (--operations-only)" Target="KOMETA_OPERATIONS_ONLY" Default="" Mode="" Description="Set as 'true' to only run library operations skipping metadata, collections, playlists, and overlays." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Overlays Only (--overlays-only)" Target="KOMETA_OVERLAYS_ONLY" Default="" Mode="" Description="Set as 'true' to only run library overlays skipping metadata, collections, playlists, and library operations." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Collections Only (--collections-only)" Target="KOMETA_COLLECTIONS_ONLY" Default="false|true" Mode="" Description="Set as 'true' to only run collection files, skip metadata, library operations, overlays, and playlists." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Metadata Only (--metadata-only)" Target="KOMETA_METADATA_ONLY" Default="false|true" Mode="" Description="Set as 'true' to only run metadata files, skip library operations, overlays, playlists, and collections." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Playlists Only (--playlists-only)" Target="KOMETA_PLAYLISTS_ONLY" Default="false|true" Mode="" Description="Set as 'true' to only run playlist files, skip metadata, library operations, overlays, and collections." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Operations Only (--operations-only)" Target="KOMETA_OPERATIONS_ONLY" Default="false|true" Mode="" Description="Set as 'true' to only run library operations skipping metadata, collections, playlists, and overlays." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Overlays Only (--overlays-only)" Target="KOMETA_OVERLAYS_ONLY" Default="false|true" Mode="" Description="Set as 'true' to only run library overlays skipping metadata, collections, playlists, and library operations." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Run Collections (--run-collections)" Target="KOMETA_RUN_COLLECTIONS" Default="" Mode="" Description="Will immediately run the comma-separated list of Collection Names given, bypassing the time to run flag." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Run Libraries (--run-libraries)" Target="KOMETA_RUN_LIBRARIES" Default="" Mode="" Description="Will immediately run the comma-separated list of Library Names given, bypassing the time to run flag." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Run Files (--run-files)" Target="KOMETA_RUN_FILES" Default="" Mode="" Description="Will immediately run the comma-separated list of File Names given, bypassing the time to run flag." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Ignore Schedules (--ignore-schedules)" Target="KOMETA_IGNORE_SCHEDULES" Default="" Mode="" Description="Set as 'true' to ignore all schedules for the run." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Ignore Ghost (--ignore-ghost)" Target="KOMETA_IGNORE_GHOST" Default="" Mode="" Description="Set as 'true' to ignore all ghost logging for the run. A ghost log is what’s printed to the console to show progress during steps." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Ignore Schedules (--ignore-schedules)" Target="KOMETA_IGNORE_SCHEDULES" Default="false|true" Mode="" Description="Set as 'true' to ignore all schedules for the run." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Ignore Ghost (--ignore-ghost)" Target="KOMETA_IGNORE_GHOST" Default="false|true" Mode="" Description="Set as 'true' to ignore all ghost logging for the run. A ghost log is what’s printed to the console to show progress during steps." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Delete Collections (--delete-collections)" Target="KOMETA_DELETE_COLLECTIONS" Default="" Mode="" Description="Set as 'true' to delete all collections in a Library prior to running collections/operations." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Delete Labels (--delete-labels)" Target="KOMETA_DELETE_LABELS" Default="" Mode="" Description="Set as 'true' to delete all labels on every item in a Library prior to running collections/operations." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Delete Labels (--delete-labels)" Target="KOMETA_DELETE_LABELS" Default="false|true" Mode="" Description="Set as 'true' to delete all labels on every item in a Library prior to running collections/operations." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Resume Run (--resume)" Target="KOMETA_RESUME" Default="" Mode="" Description="Name of Collection to immediately resume running from the first instance of the specified collection, bypassing the time to run flag." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="No Countdown (--no-countdown)" Target="KOMETA_NO_COUNTDOWN" Default="" Mode="" Description="Set as 'true' to run without displaying a countdown to the next scheduled run." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="No Missing (--no-missing)" Target="KOMETA_NO_MISSING" Default="" Mode="" Description="Set as 'true' to run without utilizing the missing movie/show functions." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="No Report (--no-report)" Target="KOMETA_NO_REPORT" Default="" Mode="" Description="Set as 'true' to run without saving the report." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Read Only Config (--read-only-config)" Target="KOMETA_READ_ONLY_CONFIG" Default="" Mode="" Description="Set as 'true' to run without writing to the configuration file." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="No Countdown (--no-countdown)" Target="KOMETA_NO_COUNTDOWN" Default="false|true" Mode="" Description="Set as 'true' to run without displaying a countdown to the next scheduled run." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="No Missing (--no-missing)" Target="KOMETA_NO_MISSING" Default="false|true" Mode="" Description="Set as 'true' to run without utilizing the missing movie/show functions." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="No Report (--no-report)" Target="KOMETA_NO_REPORT" Default="false|true" Mode="" Description="Set as 'true' to run without saving the report." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Read Only Config (--read-only-config)" Target="KOMETA_READ_ONLY_CONFIG" Default="false|true" Mode="" Description="Set as 'true' to run without writing to the configuration file." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Divider Character (--divider)" Target="KOMETA_DIVIDER" Default="" Mode="" Description="Character to use as a divider in the logs." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Screen Width (--width)" Target="KOMETA_WIDTH" Default="" Mode="" Description="Width of the Log Output. Integer between 90 and 300." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="ENV Plex URL (--plex-url)" Target="KOMETA_PLEX_URL" Default="" Mode="" Description="Plex URL to replace ENV in the config file." Type="Variable" Display="advanced" Required="false" Mask="false"/>

--- a/Overlay-Reset.xml
+++ b/Overlay-Reset.xml
@@ -4,7 +4,6 @@
   <Repository>kometateam/overlay-reset</Repository>
   <Registry>https://hub.docker.com/r/kometateam/overlay-reset</Registry>
   <Network>bridge</Network>
-  <MyIP/>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
   <Support>https://github.com/Kometa-Team/Overlay-Reset/issues/new/choose</Support>
@@ -20,16 +19,10 @@
     <Project>https://kometa.wiki/en/develop/</Project>
     <ReadMe>https://kometa.wiki/en/develop/kometa/scripts/overlay-reset/</ReadMe>
   </Branch>
-
   <Overview>Kometa Overlay Reset is a Python tool created to remove all overlays applied to a Plex library by Kometa, using methods that are not available within Kometa itself. It's typically needed when the original backup posters used by Kometa to remove overlays have been lost.</Overview>
   <Category>Tools:Utilities Status:Stable</Category>
-  <WebUI/>
-  <TemplateURL>https://github.com/Kometa-Team/Unraid-Templates/blob/master/Overlay-Reset.xml<TemplateURL>
+  <TemplateURL>https://github.com/Kometa-Team/Unraid-Templates/blob/master/Overlay-Reset.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/Kometa-Team/Overlay-Reset/refs/heads/develop/.github/logo.png</Icon>
-  <ExtraParams/>
-  <PostArgs/>
-  <CPUset/>
-  <DateInstalled>1727383014</DateInstalled>
   <DonateText>Support the Kometa Developer!</DonateText>
   <DonateLink>https://github.com/sponsors/meisnate12</DonateLink>
   <Requires/>
@@ -46,12 +39,12 @@
   <Config Name="Items (--items)" Target="ITEMS" Default="" Mode="" Description="Restore specific Plex Items by Title. Can use a bar-separated (|) list." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Labels (--labels)" Target="LABELS" Default="" Mode="" Description="Additional labels to remove. Can use a bar-separated (|) list." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Timeout (--timeout)" Target="TIMEOUT" Default="600" Mode="" Description="Connection Timeout in seconds that's greater than 0." Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Dry Run (--dry)" Target="DRY_RUN" Default="" Mode="" Description="Run as a Dry Run without making changes in Plex. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Flat Assets (--flat)" Target="KOMETA_FLAT" Default="" Mode="" Description="Kometa Asset Folder uses Flat Assets Image Paths. https://kometa.wiki/en/latest/home/guides/assets.html#asset-naming \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Reset Main Posters (--no-main)" Target="NO_MAIN" Default="" Mode="" Description="Do not restore Main Show/Movie posters during run. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Reset Season Posters (--season)" Target="SEASON" Default="" Mode="" Description="Restore Season posters during run. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Reset Episode Posters (--episode)" Target="EPISODE" Default="" Mode="" Description="Restore Episode posters during run. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Ignore Automatic Resume (--ignore-resume)" Target="IGNORE_RESUME" Default="" Mode="" Description="Ignores the automatic resume. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Trace (--trace)" Target="TRACE" Default="False" Mode="" Description="Run with extra trace logs. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
-  <Config Name="Log Requests (--log-requests)" Target="LOG_REQUESTS" Default="False" Mode="" Description="Run with every request and file action logged. \nOptions: True, False" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Dry Run (--dry)" Target="DRY_RUN" Default="False|True" Mode="" Description="Run as a Dry Run without making changes in Plex." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Flat Assets (--flat)" Target="KOMETA_FLAT" Default="False|True" Mode="" Description="Kometa Asset Folder uses Flat Assets Image Paths. https://kometa.wiki/en/latest/home/guides/assets.html#asset-naming" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Reset Main Posters (--no-main)" Target="NO_MAIN" Default="False|True" Mode="" Description="Do not restore Main Show/Movie posters during run." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Reset Season Posters (--season)" Target="SEASON" Default="False|True" Mode="" Description="Restore Season posters during run." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Reset Episode Posters (--episode)" Target="EPISODE" Default="False|True" Mode="" Description="Restore Episode posters during run." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Ignore Automatic Resume (--ignore-resume)" Target="IGNORE_RESUME" Default="False|True" Mode="" Description="Ignores the automatic resume." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Trace (--trace)" Target="TRACE" Default="False|True" Mode="" Description="Run with extra trace logs." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Log Requests (--log-requests)" Target="LOG_REQUESTS" Default="False|True" Mode="" Description="Run with every request and file action logged." Type="Variable" Display="advanced" Required="false" Mask="false"/>
 </Container>


### PR DESCRIPTION
Overlay-Reset and ImageMaid had bad XML that failed validation and prevented them from making it into the Unraid store ([logs from Unraid app store feed](https://github.com/Squidly271/AppFeed/blob/335d9ac732efb5594ea8ce570d014af0cf79a34b/log.txt#L3762)). These have been fixed.

Unraid templates also allow for enum/limited options for config variables [using the `|` character in the "Default" field](https://selfhosters.net/docker/templating/templating/#limit-config-entry-to-predefined-values). Any value with a set number of options (e.g. "true|false") have been updated. This should a) make it clearer to users what options are available/valid for a given variable and b) prevent users from entering an invalid option.

Extraneous XML values (e.g. `<MyIP/>`, `<DateInstalled/>`) has been removed. These are auto-included by the [auto-generating process](https://selfhosters.net/docker/templating/templating/#auto-generating-from-docker-image) of converting an installed Docker application into an Unraid template, but [should be stripped](https://selfhosters.net/docker/templating/templating/#4-clean-the-xml).